### PR TITLE
Add Client class and /clients endpoint with GET method to return all clients

### DIFF
--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -1,7 +1,8 @@
 import datetime
-import requests, os
+import requests
+import os
 from flask import Flask, jsonify, request, abort, make_response
-from app.models import Mentor
+from app.models import Mentor, Client
 from . import main
 from .. import db
 
@@ -30,3 +31,24 @@ def get_all_mentors():
             m = Mentor(name=name, email=email)
             list_of_mentors.append(m.serialize())
     return jsonify(list_of_mentors)
+
+
+# get all clients from Airtable
+@main.route("/clients", methods=["GET"])
+def get_all_clients():
+    response = requests.get(
+        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Clients",
+        headers={"Authorization": str(os.environ.get("API_KEY"))},
+    )
+    response_json = response.json()
+
+    list_of_clients = []
+    for r in response_json["records"]:
+        print(r["fields"])
+        name = r["fields"].get("Name")
+        notes = r["fields"].get("Notes")
+        attachments = r["fields"].get("Attachments")
+        if name is not None:
+            m = Client(name=name, notes=notes, attachments=attachments)
+            list_of_clients.append(m.serialize())
+    return jsonify(list_of_clients)

--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -24,7 +24,6 @@ def get_all_mentors():
 
     list_of_mentors = []
     for r in response_json["records"]:
-        print(r["fields"])
         name = r["fields"].get("Name")
         email = r["fields"].get("Move Up Email")
         if name is not None and email is not None:
@@ -44,7 +43,6 @@ def get_all_clients():
 
     list_of_clients = []
     for r in response_json["records"]:
-        print(r["fields"])
         name = r["fields"].get("Name")
         notes = r["fields"].get("Notes")
         attachments = r["fields"].get("Attachments")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -7,10 +7,26 @@ from werkzeug.security import generate_password_hash, check_password_hash
 
 class Mentor:
 
-    # contructor
+    # constructor
     def __init__(self, name, email):
         self.name = name
         self.email = email
 
     def serialize(self):
         return {"name": self.name, "email": self.email}
+
+
+class Client:
+
+    # constructor
+    def __init__(self, name, notes, attachments):
+        self.name = name
+        self.notes = notes
+        self.attachments = attachments
+
+    def serialize(self):
+        return {
+            "name": self.name,
+            "notes": self.notes,
+            "attachments": self.attachments
+        }


### PR DESCRIPTION
# Summary

Added a Client domain model class to **models.py** (heavily inspired by #19 ) with the parameters `name`, `notes`, and `attachments` as specified in the Airtable API docs. Added a `/clients` route to **views.py** with a GET method to return all clients.

Also added two mock clients to the Clients collection in Airtable - Dev Base.

## Test Plan

I ran `python manage.py runserver` and the Client objects were correctly returned at `http://127.0.0.1:5000/clients` in the browser.

## Related Issues

#14 and #17 
