### PR TITLE
12 get a clients profile hope

### DIFF
--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -50,3 +50,23 @@ def get_all_clients():
             m = Client(name=name, notes=notes, attachments=attachments)
             list_of_clients.append(m.serialize())
     return jsonify(list_of_clients)
+
+# get a client from Airtable 
+@main.route("/clients/<id>", methods=["GET"])
+def get_a_client(id): 
+    response = requests.get(
+        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Clients/{}".format(id),
+        headers={"Authorization": str(os.environ.get("API_KEY"))},
+    )
+    if response.status_code == 200: 
+        response_json = response.json()
+        client = []
+        name = response_json["fields"].get("Name")
+        notes = response_json["fields"].get("Notes")
+        attachments = response_json["fields"].get("Attachments")
+        if name is not None: 
+            m = Client(name=name, notes=notes, attachments=attachments)
+            client.append(m.serialize())
+            return jsonify(client)
+    else: 
+        return "This client does not exist in the database."

--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -51,22 +51,24 @@ def get_all_clients():
             list_of_clients.append(m.serialize())
     return jsonify(list_of_clients)
 
+
 # get a client from Airtable 
-@main.route("/clients/<id>", methods=["GET"])
-def get_a_client(id): 
-    response = requests.get(
-        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Clients/{}".format(id),
-        headers={"Authorization": str(os.environ.get("API_KEY"))},
-    )
-    if response.status_code == 200: 
-        response_json = response.json()
-        client = []
-        name = response_json["fields"].get("Name")
-        notes = response_json["fields"].get("Notes")
-        attachments = response_json["fields"].get("Attachments")
-        if name is not None: 
-            m = Client(name=name, notes=notes, attachments=attachments)
-            client.append(m.serialize())
-            return jsonify(client)
-    else: 
-        return "This client does not exist in the database."
+@main.route("/clients/<id>", methods=["GET"])
+def get_a_client(id):
+    response = requests.get( 
+        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Clients/{}".format(id),
+        headers={"Authorization": str(os.environ.get("API_KEY"))},
+    )
+    print(response.status_code)
+    if response.status_code == 200: 
+        response_json = response.json()
+        client = []
+        name = response_json["fields"].get("Name")
+        notes = response_json["fields"].get("Notes")
+        attachments = response_json["fields"].get("Attachments")
+        if name is not None:
+            m = Client(name=name, notes=notes, attachments=attachments)
+            client.append(m.serialize())
+            return jsonify(client)
+    else: 
+        return "This client does not exist in the database."


### PR DESCRIPTION
# Summary

Added a backend route that accepts a client's id and returns the client's name, notes and attachments (Similar to the other issues) 

Note: In this issue, I still need to create a route that accepts the client's ID and returns the info, but figured I'd put this up beforehand! 

## Test Plan

Can test by making a GET request using the airtable API to obtain an {id} related to a specific record. 
Then, call "Clients/{id}" and make sure you get the correct record returned. If the {id} does not exist in the database, a message will return with that info. 

How did you test your changes?
Tested locally with above instructions 

## Related Issues

Which issues does this PR resolve/work on?
#12 
