### PR TITLE
Add get mentor route and method

### DIFF
--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -32,6 +32,26 @@ def get_all_mentors():
     return jsonify(list_of_mentors)
 
 
+# get a mentor by email from Airtable
+@main.route("/mentors/<email>", methods=["GET"])
+def get_mentor_by_email(email):
+    response = requests.get(
+        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Mentors?filterByFormula=SEARCH('{}'".format(
+            email) + ", {Move Up Email})",
+        headers={"Authorization": str(os.environ.get("API_KEY"))},
+    )
+    if response.status_code == 200:
+        response_json = response.json()
+        mentor = response_json["records"][0]
+        name = mentor["fields"].get("Name")
+        email = mentor["fields"].get("Move Up Email")
+        if name is not None:
+            m = Mentor(name=name, email=email)
+            return jsonify(m.serialize())
+    else:
+        return "There is no mentor with that email, please try again."
+
+
 # get all clients from Airtable
 @main.route("/clients", methods=["GET"])
 def get_all_clients():


### PR DESCRIPTION
# Summary

Added a method to search by email and retrieve one mentor. Also added the corresponding route /mentors/<email>.

## Test Plan

Ran `python manage.py runserver` to run the backend and tested the mentor endpoint with several values.

## Related Issues

#10 ! Heavily inspired by #25 
