### PR TITLE
Add get mentor route and method

### DIFF
--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -19,8 +19,6 @@ def get_all_mentors():
         headers={"Authorization": str(os.environ.get("API_KEY"))},
     )
     response_json = response.json()
-    return str(response.json())
-
     list_of_mentors = []
     for r in response_json["records"]:
         name = r["fields"].get("Name")
@@ -77,8 +75,6 @@ def get_all_clients():
         headers={"Authorization": str(os.environ.get("API_KEY"))},
     )
     response_json = response.json()
-    return str(response.json())
-
     list_of_clients = []
     for r in response_json["records"]:
         name = r["fields"].get("Name")

--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -19,6 +19,7 @@ def get_all_mentors():
         headers={"Authorization": str(os.environ.get("API_KEY"))},
     )
     response_json = response.json()
+    return str(response.json())
 
     list_of_mentors = []
     for r in response_json["records"]:
@@ -30,8 +31,26 @@ def get_all_mentors():
     return jsonify(list_of_mentors)
 
 
+# get a mentor by id from Airtable
+@main.route("/mentors/<id>", methods=["GET"])
+def get_mentor_by_id(id):
+    response = requests.get(
+        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Mentors/{}".format(id),
+        headers={"Authorization": str(os.environ.get("API_KEY"))},
+    )
+    if response.status_code == 200:
+        response_json = response.json()
+        name = response_json["fields"].get("Name")
+        email = response_json["fields"].get("Move Up Email")
+        if name is not None:
+            mentor = Mentor(name=name, email=email)
+            return jsonify(mentor.serialize())
+    else:
+        return "This mentor does not exist in the database."
+
+
 # get a mentor by email from Airtable
-@main.route("/mentors/<email>", methods=["GET"])
+@main.route("/mentors/email/<email>", methods=["GET"])
 def get_mentor_by_email(email):
     response = requests.get(
         "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Mentors?filterByFormula=SEARCH('{}'".format(
@@ -40,9 +59,9 @@ def get_mentor_by_email(email):
     )
     if response.status_code == 200:
         response_json = response.json()
-        mentor = response_json["records"][0]
-        name = mentor["fields"].get("Name")
-        email = mentor["fields"].get("Move Up Email")
+    for r in response_json["records"]:
+        name = r["fields"].get("Name")
+        email = r["fields"].get("Move Up Email")
         if name is not None:
             m = Mentor(name=name, email=email)
             return jsonify(m.serialize())
@@ -58,6 +77,7 @@ def get_all_clients():
         headers={"Authorization": str(os.environ.get("API_KEY"))},
     )
     response_json = response.json()
+    return str(response.json())
 
     list_of_clients = []
     for r in response_json["records"]:
@@ -77,7 +97,6 @@ def get_a_client(id):
         "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Clients/{}".format(id),
         headers={"Authorization": str(os.environ.get("API_KEY"))},
     )
-    print(response.status_code)
     if response.status_code == 200:
         response_json = response.json()
         client = []

--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -30,6 +30,26 @@ def get_all_mentors():
     return jsonify(list_of_mentors)
 
 
+# get a mentor by email from Airtable
+@main.route("/mentors/<email>", methods=["GET"])
+def get_mentor_by_email(email):
+    response = requests.get(
+        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Mentors?filterByFormula=SEARCH('{}'".format(
+            email) + ", {Move Up Email})",
+        headers={"Authorization": str(os.environ.get("API_KEY"))},
+    )
+    if response.status_code == 200:
+        response_json = response.json()
+        mentor = response_json["records"][0]
+        name = mentor["fields"].get("Name")
+        email = mentor["fields"].get("Move Up Email")
+        if name is not None:
+            m = Mentor(name=name, email=email)
+            return jsonify(m.serialize())
+    else:
+        return "There is no mentor with that email, please try again."
+
+
 # get all clients from Airtable
 @main.route("/clients", methods=["GET"])
 def get_all_clients():
@@ -53,12 +73,12 @@ def get_all_clients():
 # get a client from Airtable 
 @main.route("/clients/<id>", methods=["GET"])
 def get_a_client(id):
-    response = requests.get( 
+    response = requests.get(
         "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Clients/{}".format(id),
         headers={"Authorization": str(os.environ.get("API_KEY"))},
     )
     print(response.status_code)
-    if response.status_code == 200: 
+    if response.status_code == 200:
         response_json = response.json()
         client = []
         name = response_json["fields"].get("Name")
@@ -68,5 +88,5 @@ def get_a_client(id):
             m = Client(name=name, notes=notes, attachments=attachments)
             client.append(m.serialize())
             return jsonify(client)
-    else: 
+    else:
         return "This client does not exist in the database."


### PR DESCRIPTION
# Summary

Added methods to search by id or email and retrieve one mentor. Also added the corresponding routes `/mentors/<id>` and `/mentors/email/<email>`.

Replaces [former PR](https://github.com/hack4impact-mcgill/move-up-crm-tool/pull/31) from a fork.

## Test Plan

`python manage.py runserver` to run the backend and tested both endpoints with positive and negative values.

## Related Issues

#10 
