### PR TITLE
Added pagination for get all clients

### DIFF
--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -105,8 +105,6 @@ def get_all_clients():
             if name is not None:
                 m = Client(name=name, email=email, notes=notes, attachments=attachments)
                 list_of_clients.append(m.serialize())
-        if 'offset' in response_json:
-            offset = response_json["offset"]
     return jsonify(list_of_clients)
 
 

--- a/backend/app/main/views.py
+++ b/backend/app/main/views.py
@@ -88,6 +88,25 @@ def get_all_clients():
         if name is not None:
             m = Client(name=name, email=email, notes=notes, attachments=attachments)
             list_of_clients.append(m.serialize())
+            
+    # Pagination setting that will continue to send requests until all of the records have been retrieved
+    while 'offset' in response_json: 
+        offset = response_json["offset"]
+        response = requests.get(
+        "https://api.airtable.com/v0/appw4RRMDig1g2PFI/Clients?offset={}".format(offset),
+        headers={"Authorization": str(os.environ.get("API_KEY"))},
+        )
+        response_json = response.json()
+        for r in response_json["records"]:
+            name = r["fields"].get("Name")
+            notes = r["fields"].get("Notes")
+            email = r["fields"].get("Client Email")
+            attachments = r["fields"].get("Attachments")
+            if name is not None:
+                m = Client(name=name, email=email, notes=notes, attachments=attachments)
+                list_of_clients.append(m.serialize())
+        if 'offset' in response_json:
+            offset = response_json["offset"]
     return jsonify(list_of_clients)
 
 


### PR DESCRIPTION
# Summary

In order to retrieve more than 100 records at a time, a pagination feature needed to be implemented. Using Airtable's API, I continue to make a get request until all of the clients have been retrieved. Airtable has a feature where if there are more than 100 clients, it will include an offset parameter that we can pass in to get the next 100 or so clients. 

## Test Plan

I made 200 clients in the airtable dev base lol and made a get request on local host. 

